### PR TITLE
Fix code scanning alert no. 11: Uncontrolled command line

### DIFF
--- a/WebGoat/App_Code/Util.cs
+++ b/WebGoat/App_Code/Util.cs
@@ -13,6 +13,11 @@ namespace OWASP.WebGoat.NET.App_Code
         
         public static int RunProcessWithInput(string cmd, string args, string input)
         {
+            if (!IsValidArgument(args))
+            {
+                throw new ArgumentException("Invalid arguments provided.");
+            }
+
             ProcessStartInfo startInfo = new ProcessStartInfo
             {
                 WorkingDirectory = Settings.RootDir,
@@ -88,6 +93,20 @@ namespace OWASP.WebGoat.NET.App_Code
                     return 1;
                 }
             }
+        }
+
+        private static bool IsValidArgument(string args)
+        {
+            // Implement validation logic here
+            // For example, only allow alphanumeric characters and spaces
+            foreach (char c in args)
+            {
+                if (!char.IsLetterOrDigit(c) && !char.IsWhiteSpace(c))
+                {
+                    return false;
+                }
+            }
+            return true;
         }
     }
 }


### PR DESCRIPTION
Fixes [https://github.com/evgeny-belov-webjet/ghas-demo-csharp/security/code-scanning/11](https://github.com/evgeny-belov-webjet/ghas-demo-csharp/security/code-scanning/11)

To fix the problem, we need to ensure that the `args` parameter is sanitized or validated before being used in the `ProcessStartInfo.Arguments` property. One way to do this is to use a whitelist approach, where only known safe commands and arguments are allowed. Alternatively, we can escape any potentially dangerous characters in the `args` parameter.

The best way to fix this issue without changing existing functionality is to validate the `args` parameter against a whitelist of allowed commands and arguments. If the `args` parameter contains any disallowed characters or commands, we should reject it.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
