### PR TITLE
Fix code scanning alert no. 22: XPath injection

### DIFF
--- a/WebGoat/Content/XPathInjection.aspx.cs
+++ b/WebGoat/Content/XPathInjection.aspx.cs
@@ -5,6 +5,7 @@ using System.Web;
 using System.Web.UI;
 using System.Web.UI.WebControls;
 using System.Xml;
+using System.Xml.Xsl;
 using System.Xml.XPath;
 
 namespace OWASP.WebGoat.NET
@@ -25,7 +26,16 @@ namespace OWASP.WebGoat.NET
         {
             XmlDocument xDoc = new XmlDocument();
             xDoc.LoadXml(xml);
-            XmlNodeList list = xDoc.SelectNodes("//salesperson[state='" + state + "']");
+            string xpathExpression = "//salesperson[state=$state]";
+            XPathExpression expr = xDoc.CreateNavigator().Compile(xpathExpression);
+
+            XsltArgumentList varList = new XsltArgumentList();
+            varList.AddParam("state", "", state);
+
+            CustomContext context = new CustomContext(new NameTable(), varList);
+            expr.SetContext(context);
+
+            XmlNodeList list = xDoc.SelectNodes(expr.Expression);
             if (list.Count > 0)
             {
 
@@ -33,5 +43,40 @@ namespace OWASP.WebGoat.NET
 
         }
     }
-}
 
+    public class CustomContext : XsltContext
+    {
+        private readonly XsltArgumentList _args;
+
+        public CustomContext(NameTable nt, XsltArgumentList args) : base(nt)
+        {
+            _args = args;
+        }
+
+        public override IXsltContextVariable ResolveVariable(string prefix, string name)
+        {
+            return new CustomVariable(_args.GetParam(name, ""));
+        }
+
+        public override bool Whitespace => false;
+        public override bool PreserveWhitespace(XPathNavigator node) => false;
+        public override int CompareDocument(string baseUri, string nextbaseUri) => 0;
+        public override bool PreserveWhitespace(XPathNavigator node) => false;
+        public override IXsltContextFunction ResolveFunction(string prefix, string name, XPathResultType[] ArgTypes) => null;
+    }
+
+    public class CustomVariable : IXsltContextVariable
+    {
+        private readonly object _value;
+
+        public CustomVariable(object value)
+        {
+            _value = value;
+        }
+
+        public bool IsLocal => false;
+        public bool IsParam => true;
+        public XPathResultType VariableType => XPathResultType.Any;
+        public object Evaluate(XsltContext xsltContext) => _value;
+    }
+}


### PR DESCRIPTION
Fixes [https://github.com/evgeny-belov-webjet/ghas-demo-csharp/security/code-scanning/22](https://github.com/evgeny-belov-webjet/ghas-demo-csharp/security/code-scanning/22)

To fix the XPath injection vulnerability, we need to avoid directly concatenating user input into the XPath expression. Instead, we should use parameterized queries. This can be achieved by creating a custom `XsltContext` and using `XsltArgumentList` to safely include user input in the XPath expression.

1. Create a custom `XsltContext` class that resolves variables.
2. Modify the `FindSalesPerson` method to use this custom context and safely include the user input.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
